### PR TITLE
Add Toast concept screen with example

### DIFF
--- a/.idea/markdown.xml
+++ b/.idea/markdown.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MarkdownSettings">
+    <option name="previewPanelProviderInfo">
+      <ProviderInfo name="Compose (experimental)" className="com.intellij.markdown.compose.preview.ComposePanelProvider" />
+    </option>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
   <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,9 @@
         android:theme="@style/Theme.AndroidTutor"
         tools:targetApi="31">
         <activity
+            android:name=".ToastConceptActivity"
+            android:exported="false" />
+        <activity
             android:name=".ConceptsListScreen"
             android:exported="false" />
         <activity

--- a/app/src/main/java/com/example/androidtutor/ConceptsListScreen.java
+++ b/app/src/main/java/com/example/androidtutor/ConceptsListScreen.java
@@ -11,6 +11,9 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
+import android.content.Intent;
+import android.widget.Button;
+
 
 public class ConceptsListScreen extends AppCompatActivity {
 
@@ -21,6 +24,13 @@ public class ConceptsListScreen extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         EdgeToEdge.enable(this);
         setContentView(R.layout.activity_concepts_list_screen);
+        Button toastBtn = findViewById(R.id.toastConceptBtn);
+
+        toastBtn.setOnClickListener(v -> {
+            Intent intent = new Intent(ConceptsListScreen.this, ToastConceptActivity.class);
+            startActivity(intent);
+        });
+
         ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main), (v, insets) -> {
             Insets systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars());
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom);

--- a/app/src/main/java/com/example/androidtutor/ToastConceptActivity.java
+++ b/app/src/main/java/com/example/androidtutor/ToastConceptActivity.java
@@ -1,0 +1,27 @@
+package com.example.androidtutor;
+
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+
+public class ToastConceptActivity extends AppCompatActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_toast_concept);
+
+        Button btnToast = findViewById(R.id.btnShowToast);
+
+        btnToast.setOnClickListener(v ->
+                Toast.makeText(
+                        ToastConceptActivity.this,
+                        "This is a Toast message!",
+                        Toast.LENGTH_SHORT
+                ).show()
+        );
+    }
+}
+

--- a/app/src/main/res/layout-land/activity_toast_concept.xml
+++ b/app/src/main/res/layout-land/activity_toast_concept.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ToastConceptActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/activity_concepts_list_screen.xml
+++ b/app/src/main/res/layout/activity_concepts_list_screen.xml
@@ -7,6 +7,7 @@
     android:layout_height="match_parent"
     tools:context=".ConceptsListScreen">
 
+
     <TextView
         android:id="@+id/textView2"
         android:layout_width="358dp"
@@ -20,6 +21,17 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias="0.177" />
+
+    <Button
+        android:id="@+id/toastConceptBtn"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Toast Concept"
+        android:layout_marginTop="16dp"
+        app:layout_constraintTop_toBottomOf="@id/textView2"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 
     <TextView
         android:id="@+id/textView3"

--- a/app/src/main/res/layout/activity_toast_concept.xml
+++ b/app/src/main/res/layout/activity_toast_concept.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="16dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Toast Concept"
+        android:textSize="20sp"
+        android:textStyle="bold"
+        android:layout_marginBottom="20dp"/>
+
+    <Button
+        android:id="@+id/btnShowToast"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Show Toast"/>
+</LinearLayout>


### PR DESCRIPTION
This PR adds a new beginner-friendly Toast concept screen to the Android Tutor project.

The screen demonstrates basic usage of Toast in Android using Java, with a simple UI and a button that triggers a Toast message. This helps beginners understand how Toast works in a practical way.

Notes:
- The Toast concept is implemented as a standalone activity.
- Navigation from the Concepts List screen can be added in a follow-up PR if required.

Please review and let me know if any changes are needed.
